### PR TITLE
Correct a package name

### DIFF
--- a/dtk/ui/gsettings.py
+++ b/dtk/ui/gsettings.py
@@ -26,7 +26,7 @@ try:
     DESKTOP_SETTINGS = deepin_gsettings.new(DESKTOP_SETTINGS_CONF)
 except ImportError:
     print "----------Please Install Deepin GSettings Python Binding----------"
-    print "sudo apt-get install deepin-gsettings"
+    print "sudo apt-get install python-deepin-gsettings"
     print "------------------------------------------------------------------"
 
 DEFAULT_CURSOR_BLINK_TIME = 600  # microsecond


### PR DESCRIPTION
The package deepin-gsettings already changed to python-deepin-gsettings, so I changed this package name to python-deepin-gsettings.
